### PR TITLE
bugfix for issue wuetherich/ds-annotation-builder#38

### DIFF
--- a/com.wuetherich.osgi.ds.annotations.ds-annotation-builder/com.wuetherich.osgi.ds.annotations/src/com/wuetherich/osgi/ds/annotations/internal/builder/ManifestAndBuildPropertiesUpdater.java
+++ b/com.wuetherich.osgi.ds.annotations.ds-annotation-builder/com.wuetherich.osgi.ds.annotations/src/com/wuetherich/osgi/ds/annotations/internal/builder/ManifestAndBuildPropertiesUpdater.java
@@ -11,6 +11,7 @@
 package com.wuetherich.osgi.ds.annotations.internal.builder;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -67,6 +68,9 @@ public class ManifestAndBuildPropertiesUpdater {
             descriptions.add(iPath.toPortableString());
           }
         }
+        
+        // Bug-Fix: https://github.com/wuetherich/ds-annotation-builder/issues/38
+        Collections.sort(descriptions);
 
         //
         StringBuilder stringBuilder = new StringBuilder();


### PR DESCRIPTION
This change sorts `Service-Component:` entries alphabetically. This way, the ordering is always the same.

This change fixes issue https://github.com/wuetherich/ds-annotation-builder/issues/38.
